### PR TITLE
Update new versions of RubyInstaller

### DIFF
--- a/share/ruby-build/2.0.0-p647-i386-mingw32
+++ b/share/ruby-build/2.0.0-p647-i386-mingw32
@@ -1,0 +1,2 @@
+DEVKIT_VERSION="DevKit-mingw64-32-4.7.2-20130224-1151"
+install_7z "ruby-2.0.0-p647-i386-mingw32" "http://dl.bintray.com/oneclick/rubyinstaller/ruby-2.0.0-p647-i386-mingw32.7z#a65e229c275993898e72cea690a5db1b" "" mingw devkit

--- a/share/ruby-build/2.0.0-p647-x64-mingw32
+++ b/share/ruby-build/2.0.0-p647-x64-mingw32
@@ -1,0 +1,2 @@
+DEVKIT_VERSION="DevKit-mingw64-64-4.7.2-20130224-1432"
+install_7z "ruby-2.0.0-p647-x64-mingw32" "http://dl.bintray.com/oneclick/rubyinstaller/ruby-2.0.0-p647-x64-mingw32.7z#d641e1a26e17d15d0419c7e3830e5683" "" mingw devkit

--- a/share/ruby-build/2.1.7-i386-mingw32
+++ b/share/ruby-build/2.1.7-i386-mingw32
@@ -1,0 +1,2 @@
+DEVKIT_VERSION="DevKit-mingw64-32-4.7.2-20130224-1151"
+install_7z "ruby-2.1.7-i386-mingw32" "http://dl.bintray.com/oneclick/rubyinstaller/ruby-2.1.7-i386-mingw32.7z#ed0af70cb991bc30a4a78f39e02f39de" "" mingw devkit

--- a/share/ruby-build/2.1.7-x64-mingw32
+++ b/share/ruby-build/2.1.7-x64-mingw32
@@ -1,0 +1,2 @@
+DEVKIT_VERSION="DevKit-mingw64-64-4.7.2-20130224-1432"
+install_7z "ruby-2.1.7-x64-mingw32" "http://dl.bintray.com/oneclick/rubyinstaller/ruby-2.1.7-x64-mingw32.7z#6f77454f8c3935f0113707b8f65faf14" "" mingw devkit

--- a/share/ruby-build/2.2.3-i386-mingw32
+++ b/share/ruby-build/2.2.3-i386-mingw32
@@ -1,0 +1,2 @@
+DEVKIT_VERSION="DevKit-mingw64-32-4.7.2-20130224-1151"
+install_7z "ruby-2.2.3-i386-mingw32" "http://dl.bintray.com/oneclick/rubyinstaller/ruby-2.2.3-i386-mingw32.7z#8d7d94856bd7c9498c48a9b8d155c926" "" mingw devkit

--- a/share/ruby-build/2.2.3-x64-mingw32
+++ b/share/ruby-build/2.2.3-x64-mingw32
@@ -1,0 +1,2 @@
+DEVKIT_VERSION="DevKit-mingw64-64-4.7.2-20130224-1432"
+install_7z "ruby-2.2.3-x64-mingw32" "http://dl.bintray.com/oneclick/rubyinstaller/ruby-2.2.3-x64-mingw32.7z#77bfcf4b65ec8d5ba0cd84779f3eff7c" "" mingw devkit


### PR DESCRIPTION
Add new versions of RubyInstaller 2.0.0-p647, 2.1.7 and 2.2.3.
It works, but I could not merge the original master (sstephenson/ruby-build) without failure.
